### PR TITLE
feat: add multi-app coverage collection via dep_apps option

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@main
+        with:
+          fetch-depth: 0
       - uses: erlef/setup-beam@main
         with:
           otp-version: ${{matrix.otp}}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ExIntegrationCoveralls
 
+[中文文档](README_CN.md)
+
 [![Coverage Status](https://coveralls.io/repos/github/yeshan333/ex_integration_coveralls/badge.svg?branch=main)](https://coveralls.io/github/yeshan333/ex_integration_coveralls?branch=main) [![hex.pm version](https://img.shields.io/hexpm/v/ex_integration_coveralls.svg)](https://hex.pm/packages/ex_integration_coveralls) [![hex.pm downloads](https://img.shields.io/hexpm/dt/ex_integration_coveralls.svg)](https://hex.pm/packages/ex_integration_coveralls) [![hex.pm license](https://img.shields.io/hexpm/l/ex_integration_coveralls.svg)](https://github.com/yeshan333/ex_integration_coveralls/blog/main/LICENSE)
 
 A library for run-time system code line-level coverage analysis. You can use it to evaluate the intergration test coverage.
@@ -90,7 +92,58 @@ Note: Your application release package should include the source code. ExIntegra
     └── start_erl.data
 ```
 
-Note: If you use the [distillery](https://github.com/bitwalker/distillery) to get OTP release, and config `set include_src: true`, then you can get the above structure. But if you use the Elixir origin `mix release`, this situation needs to be handled manually.
+Note: If you use the [distillery](https://github.com/bitwalker/distillery) to get OTP release, and config `set include_src: true`, then you can get the above structure. But if you use the Elixir origin `mix release`, this situation needs to be handled manually. See the [release demo](examples/release_demo) for a working example with a custom release step that copies source files automatically.
+
+## Multi-App Coverage (dep_apps)
+
+In real projects, business logic often lives in custom dependency libraries. You can collect coverage across your main app **and** its dependencies in a single session by passing the `dep_apps` option:
+
+```elixir
+# Start coverage for the main app and its dependencies
+ExIntegrationCoveralls.start_app_cov("my_app", dep_apps: ["shared_lib", "domain_logic"])
+
+# Get merged total coverage across all apps
+ExIntegrationCoveralls.get_app_total_cov("my_app", dep_apps: ["shared_lib", "domain_logic"])
+
+# Post merged coverage data to CI
+ExIntegrationCoveralls.post_app_cov_to_ci(url, extends, "my_app", dep_apps: ["shared_lib"])
+```
+
+The HTTP API also supports `dep_apps`:
+
+```bash
+# Start coverage with dependencies
+curl -X POST http://localhost:3333/cov/start \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "my_app", "dep_apps": ["shared_lib"]}'
+
+# Get total coverage (comma-separated query param)
+curl http://localhost:3333/cov/total/my_app?dep_apps=shared_lib
+
+# Get detailed line-level report
+curl http://localhost:3333/cov/report/my_app?dep_apps=shared_lib
+```
+
+## Examples
+
+The [`examples/`](examples/) directory contains a complete working demo:
+
+| Directory | Description |
+|-----------|-------------|
+| [`examples/release_demo/`](examples/release_demo/) | Main OTP app demonstrating `mix release` integration with `ex_integration_coveralls`. Includes a smoke test script exercising all HTTP endpoints. |
+| [`examples/dep_lib/`](examples/dep_lib/) | A minimal dependency library used by `release_demo` to demonstrate multi-app coverage collection via `dep_apps`. |
+
+To try it out:
+
+```bash
+cd examples/release_demo
+mix deps.get
+MIX_ENV=prod mix release
+_build/prod/rel/release_demo/bin/release_demo daemon
+bash smoke_test.sh
+```
+
+See the [release demo README](examples/release_demo/README.md) for full details.
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,160 @@
+# ExIntegrationCoveralls
+
+[English](README.md)
+
+[![Coverage Status](https://coveralls.io/repos/github/yeshan333/ex_integration_coveralls/badge.svg?branch=main)](https://coveralls.io/github/yeshan333/ex_integration_coveralls?branch=main) [![hex.pm version](https://img.shields.io/hexpm/v/ex_integration_coveralls.svg)](https://hex.pm/packages/ex_integration_coveralls) [![hex.pm downloads](https://img.shields.io/hexpm/dt/ex_integration_coveralls.svg)](https://hex.pm/packages/ex_integration_coveralls) [![hex.pm license](https://img.shields.io/hexpm/l/ex_integration_coveralls.svg)](https://github.com/yeshan333/ex_integration_coveralls/blog/main/LICENSE)
+
+一个用于运行时系统代码行级覆盖率分析的库。可用于评估集成测试覆盖率。
+
+> 实践案例:
+> - [en](https://github.com/yeshan333/explore_ast_app/blob/main/examples/README.md)
+> - [zh_hans 中文版](https://github.com/yeshan333/explore_ast_app/blob/main/examples/README_cn.md)
+
+## 运行测试
+
+使用覆盖率数据运行测试：
+
+```shell
+mix test --cover --exclude real_cover
+```
+
+## 安装
+
+在 `mix.exs` 的依赖列表中添加 `ex_integration_coveralls`：
+
+```elixir
+def deps do
+  [
+    {:ex_integration_coveralls, "~> 0.9.0"}
+  ]
+end
+```
+
+文档地址：[https://hexdocs.pm/ex_integration_coveralls](https://hexdocs.pm/ex_integration_coveralls/readme.html)。
+
+## 快速开始
+
+应用发布并运行后，只需以下三步即可进行运行时覆盖率采集：
+
+- 第 1 步、连接到运行中的节点：
+
+```shell
+/path/bin/your_app remote_console
+```
+
+- 第 2 步、指定应用启动覆盖率采集：
+
+```shell
+ExIntegrationCoveralls.start_app_cov("your_app_name")
+```
+
+注意：`your_app_name` 必须存在于 [:application.which_applications](https://www.erlang.org/doc/man/application.html#which_applications-0) 返回的应用列表中。
+
+- 第 3 步、对上述应用进行外部测试，获取运行时覆盖率或将覆盖率数据推送到覆盖率系统。
+
+```shell
+ExIntegrationCoveralls.get_app_total_cov("your_app_name")
+# 推送覆盖率数据
+ExIntegrationCoveralls.post_app_cov_to_ci(url, extends, "your_app_name")
+```
+
+注意：应用发布包应包含源代码。ExIntegrationCoveralls 将使用源代码来计算覆盖率统计数据。一般结构如下：
+
+```shell
+.
+├── bin
+│   ├── explore_ast_app
+│   ├── explore_ast_app.bat
+│   ├── explore_ast_app_rc_exec.sh
+│   ├── no_dot_erlang.boot
+│   └── start_clean.boot
+├── erts-12.1
+│   ├── bin
+│   ├── doc
+│   ├── include
+│   ├── info
+│   ├── lib
+│   └── src
+├── lib
+│   ├── artificery-0.4.3
+│   ├── asn1-5.0.17
+│   ├── certifi-2.9.0
+│   ├── elixir-1.12.3
+│   ├── ex_integration_coveralls-0.4.0 # 运行中的应用
+│   ├── explore_ast_app-0.1.0
+│   │   ├── consolidated
+│   │   ├── ebin
+│   │   └── lib                        # 源代码在此
+│   └── unicode_util_compat-0.7.0
+└── releases
+    ├── 0.1.0
+    ├── RELEASES
+    └── start_erl.data
+```
+
+注意：如果使用 [distillery](https://github.com/bitwalker/distillery) 进行 OTP release，配置 `set include_src: true` 即可获得上述结构。但如果使用 Elixir 原生 `mix release`，需要手动处理。参见 [release demo](examples/release_demo) 获取一个包含自定义 release 步骤的完整示例，可自动复制源文件。
+
+## 多应用覆盖率采集 (dep_apps)
+
+在实际项目中，业务逻辑通常分布在多个自定义依赖库中。通过 `dep_apps` 选项，可以在一个覆盖率会话中同时采集主应用及其依赖库的覆盖率：
+
+```elixir
+# 启动主应用和依赖库的覆盖率采集
+ExIntegrationCoveralls.start_app_cov("my_app", dep_apps: ["shared_lib", "domain_logic"])
+
+# 获取合并后的总覆盖率
+ExIntegrationCoveralls.get_app_total_cov("my_app", dep_apps: ["shared_lib", "domain_logic"])
+
+# 将合并的覆盖率数据推送到 CI 系统
+ExIntegrationCoveralls.post_app_cov_to_ci(url, extends, "my_app", dep_apps: ["shared_lib"])
+```
+
+HTTP API 同样支持 `dep_apps`：
+
+```bash
+# 启动覆盖率采集（包含依赖）
+curl -X POST http://localhost:3333/cov/start \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "my_app", "dep_apps": ["shared_lib"]}'
+
+# 获取合并后的总覆盖率（逗号分隔的查询参数）
+curl http://localhost:3333/cov/total/my_app?dep_apps=shared_lib
+
+# 获取详细的行级覆盖率报告
+curl http://localhost:3333/cov/report/my_app?dep_apps=shared_lib
+```
+
+## 示例
+
+[`examples/`](examples/) 目录包含一个完整的可运行演示：
+
+| 目录 | 说明 |
+|------|------|
+| [`examples/release_demo/`](examples/release_demo/) | 主 OTP 应用，演示 `mix release` 与 `ex_integration_coveralls` 的集成。包含 smoke test 脚本，覆盖所有 HTTP 端点。 |
+| [`examples/dep_lib/`](examples/dep_lib/) | 一个小型依赖库，被 `release_demo` 使用，演示通过 `dep_apps` 进行多应用覆盖率采集。 |
+
+快速体验：
+
+```bash
+cd examples/release_demo
+mix deps.get
+MIX_ENV=prod mix release
+_build/prod/rel/release_demo/bin/release_demo daemon
+bash smoke_test.sh
+```
+
+详见 [release demo README](examples/release_demo/README_CN.md)。
+
+## 许可证
+
+基于 MIT 许可证分发。详见 [LICENSE](LICENSE)。
+
+## 致谢
+
+感谢以下在 **ExIntegrationCoveralls** 开发过程中使用的优秀资源：
+
+- [Erlang cover](https://www.erlang.org/doc/man/cover.html#description)
+- [A brief introduction to BEAM](https://www.erlang.org/blog/a-brief-beam-primer/)
+- [excoveralls](https://github.com/parroty/excoveralls)
+- [BeamFile - A peek into the BEAM file](https://github.com/hrzndhrn/beam_file)
+- [The Elixir AST explorer - ast_ninja](https://github.com/arjan/ast_ninja)

--- a/examples/dep_lib/lib/dep_lib.ex
+++ b/examples/dep_lib/lib/dep_lib.ex
@@ -1,0 +1,16 @@
+defmodule DepLib do
+  @moduledoc """
+  A small dependency library used to demonstrate multi-app coverage collection.
+  """
+
+  def multiply(a, b) do
+    a * b
+  end
+
+  def reverse_string(str) do
+    str |> String.graphemes() |> Enum.reverse() |> Enum.join()
+  end
+
+  def factorial(0), do: 1
+  def factorial(n) when n > 0, do: n * factorial(n - 1)
+end

--- a/examples/dep_lib/mix.exs
+++ b/examples/dep_lib/mix.exs
@@ -1,0 +1,23 @@
+defmodule DepLib.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dep_lib,
+      version: "0.1.0",
+      elixir: "~> 1.12",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/examples/release_demo/README.md
+++ b/examples/release_demo/README.md
@@ -1,0 +1,137 @@
+# Release Demo
+
+[中文文档](README_CN.md)
+
+Demonstrates `ex_integration_coveralls` in a `mix release` context, including multi-app coverage collection via `dep_apps`.
+
+## Project Structure
+
+```
+examples/
+├── dep_lib/          # A small dependency library (coverage target)
+│   ├── mix.exs
+│   └── lib/dep_lib.ex
+└── release_demo/     # Main OTP app
+    ├── mix.exs       # depends on ex_integration_coveralls + dep_lib
+    ├── smoke_test.sh # end-to-end HTTP API smoke tests
+    ├── config/
+    └── lib/
+```
+
+`release_demo` depends on `dep_lib` via `path: "../dep_lib"`. Both are packaged into the same release and can be instrumented for coverage together.
+
+## Quick Start
+
+```bash
+cd examples/release_demo
+
+# Install dependencies
+mix deps.get
+
+# Build the release
+MIX_ENV=prod mix release
+
+# Start the release (background)
+_build/prod/rel/release_demo/bin/release_demo daemon
+
+# Run the smoke tests
+bash smoke_test.sh
+
+# Stop the release
+_build/prod/rel/release_demo/bin/release_demo stop
+```
+
+## HTTP API
+
+### Single-App Coverage
+
+```bash
+# Start coverage for release_demo only
+curl -X POST http://localhost:3333/cov/start \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "release_demo"}'
+
+# Get total coverage
+curl http://localhost:3333/cov/total/release_demo
+```
+
+### Multi-App Coverage (dep_apps)
+
+Collect coverage across `release_demo` and its dependency `dep_lib` in a single session:
+
+```bash
+# Start coverage for release_demo + dep_lib
+curl -X POST http://localhost:3333/cov/start \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "release_demo", "dep_apps": ["dep_lib"]}'
+
+# Get merged total coverage (query param: comma-separated)
+curl http://localhost:3333/cov/total/release_demo?dep_apps=dep_lib
+
+# Get detailed report with files from both apps
+curl http://localhost:3333/cov/report/release_demo?dep_apps=dep_lib
+```
+
+### Other Endpoints
+
+```bash
+# Health check
+curl http://localhost:3333/ping
+
+# Cover server status
+curl http://localhost:3333/cov/status
+```
+
+## Elixir API (via remote console)
+
+```bash
+_build/prod/rel/release_demo/bin/release_demo remote
+```
+
+```elixir
+# Single app
+ExIntegrationCoveralls.start_app_cov("release_demo")
+ExIntegrationCoveralls.get_app_total_cov("release_demo")
+
+# Multi-app with dep_apps
+ExIntegrationCoveralls.start_app_cov("release_demo", dep_apps: ["dep_lib"])
+ExIntegrationCoveralls.get_app_total_cov("release_demo", dep_apps: ["dep_lib"])
+```
+
+## Release Configuration Notes
+
+### Source Files Must Be Included
+
+`ex_integration_coveralls` reads source files at runtime to compute line-level coverage. In a `mix release`, source files are **not** included by default — only compiled `.beam` files are packaged.
+
+This demo solves it with a custom release step in `mix.exs`:
+
+```elixir
+releases: [
+  release_demo: [
+    strip_beams: [keep: ["Docs", "Dbgi"]],
+    steps: [:assemble, &copy_app_sources/1]
+  ]
+]
+
+defp copy_app_sources(release) do
+  release_lib = Path.join(release.path, "lib")
+  for {app, src} <- [{:release_demo, "lib"}, {:dep_lib, "../dep_lib/lib"}] do
+    [target] = Path.wildcard(Path.join(release_lib, "#{app}-*"))
+    File.cp_r!(src, Path.join(target, "lib"))
+  end
+  release
+end
+```
+
+### Debug Info Must Be Preserved
+
+The `strip_beams: [keep: ["Docs", "Dbgi"]]` option preserves the `Dbgi` chunk in beam files. This is required for `ex_integration_coveralls` to resolve compile-time source paths in release environments where `module_info(:compile)` is stripped.
+
+### Configuration
+
+Port can be set via `COV_PORT` environment variable (default: 3333):
+
+```bash
+COV_PORT=4000 _build/prod/rel/release_demo/bin/release_demo start
+```

--- a/examples/release_demo/README_CN.md
+++ b/examples/release_demo/README_CN.md
@@ -1,0 +1,137 @@
+# Release Demo
+
+[English](README.md)
+
+演示 `ex_integration_coveralls` 在 `mix release` 环境下的使用，包括通过 `dep_apps` 进行多应用覆盖率采集。
+
+## 项目结构
+
+```
+examples/
+├── dep_lib/          # 小型依赖库（覆盖率采集目标）
+│   ├── mix.exs
+│   └── lib/dep_lib.ex
+└── release_demo/     # 主 OTP 应用
+    ├── mix.exs       # 依赖 ex_integration_coveralls + dep_lib
+    ├── smoke_test.sh # 端到端 HTTP API 冒烟测试
+    ├── config/
+    └── lib/
+```
+
+`release_demo` 通过 `path: "../dep_lib"` 依赖 `dep_lib`。两者打包在同一个 release 中，可以一起进行覆盖率采集。
+
+## 快速开始
+
+```bash
+cd examples/release_demo
+
+# 安装依赖
+mix deps.get
+
+# 构建 release
+MIX_ENV=prod mix release
+
+# 启动 release（后台运行）
+_build/prod/rel/release_demo/bin/release_demo daemon
+
+# 运行冒烟测试
+bash smoke_test.sh
+
+# 停止 release
+_build/prod/rel/release_demo/bin/release_demo stop
+```
+
+## HTTP API
+
+### 单应用覆盖率
+
+```bash
+# 启动 release_demo 的覆盖率采集
+curl -X POST http://localhost:3333/cov/start \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "release_demo"}'
+
+# 获取总覆盖率
+curl http://localhost:3333/cov/total/release_demo
+```
+
+### 多应用覆盖率（dep_apps）
+
+在一个会话中同时采集 `release_demo` 及其依赖 `dep_lib` 的覆盖率：
+
+```bash
+# 启动 release_demo + dep_lib 的覆盖率采集
+curl -X POST http://localhost:3333/cov/start \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "release_demo", "dep_apps": ["dep_lib"]}'
+
+# 获取合并后的总覆盖率（查询参数：逗号分隔）
+curl http://localhost:3333/cov/total/release_demo?dep_apps=dep_lib
+
+# 获取包含两个应用文件的详细报告
+curl http://localhost:3333/cov/report/release_demo?dep_apps=dep_lib
+```
+
+### 其他端点
+
+```bash
+# 健康检查
+curl http://localhost:3333/ping
+
+# Cover 服务状态
+curl http://localhost:3333/cov/status
+```
+
+## Elixir API（通过远程控制台）
+
+```bash
+_build/prod/rel/release_demo/bin/release_demo remote
+```
+
+```elixir
+# 单应用
+ExIntegrationCoveralls.start_app_cov("release_demo")
+ExIntegrationCoveralls.get_app_total_cov("release_demo")
+
+# 多应用（dep_apps）
+ExIntegrationCoveralls.start_app_cov("release_demo", dep_apps: ["dep_lib"])
+ExIntegrationCoveralls.get_app_total_cov("release_demo", dep_apps: ["dep_lib"])
+```
+
+## Release 配置说明
+
+### 必须包含源文件
+
+`ex_integration_coveralls` 在运行时读取源文件来计算行级覆盖率。在 `mix release` 中，默认**不包含**源文件——只打包编译后的 `.beam` 文件。
+
+本示例通过 `mix.exs` 中的自定义 release 步骤解决此问题：
+
+```elixir
+releases: [
+  release_demo: [
+    strip_beams: [keep: ["Docs", "Dbgi"]],
+    steps: [:assemble, &copy_app_sources/1]
+  ]
+]
+
+defp copy_app_sources(release) do
+  release_lib = Path.join(release.path, "lib")
+  for {app, src} <- [{:release_demo, "lib"}, {:dep_lib, "../dep_lib/lib"}] do
+    [target] = Path.wildcard(Path.join(release_lib, "#{app}-*"))
+    File.cp_r!(src, Path.join(target, "lib"))
+  end
+  release
+end
+```
+
+### 必须保留调试信息
+
+`strip_beams: [keep: ["Docs", "Dbgi"]]` 选项保留了 beam 文件中的 `Dbgi` chunk。这是 `ex_integration_coveralls` 在 release 环境中解析编译时源路径所必需的，因为 `module_info(:compile)` 在 strip 后会被移除。
+
+### 配置
+
+端口可通过 `COV_PORT` 环境变量设置（默认：3333）：
+
+```bash
+COV_PORT=4000 _build/prod/rel/release_demo/bin/release_demo start
+```

--- a/examples/release_demo/config/dev.exs
+++ b/examples/release_demo/config/dev.exs
@@ -1,0 +1,1 @@
+import Config

--- a/examples/release_demo/config/test.exs
+++ b/examples/release_demo/config/test.exs
@@ -1,0 +1,1 @@
+import Config

--- a/examples/release_demo/lib/release_demo.ex
+++ b/examples/release_demo/lib/release_demo.ex
@@ -14,4 +14,11 @@ defmodule ReleaseDemo do
   def greet(name) do
     "Hello, #{name}!"
   end
+
+  @doc """
+  Demonstrates cross-app call: uses DepLib.multiply/2 from the dep_lib dependency.
+  """
+  def square(n) do
+    DepLib.multiply(n, n)
+  end
 end

--- a/examples/release_demo/mix.exs
+++ b/examples/release_demo/mix.exs
@@ -11,7 +11,8 @@ defmodule ReleaseDemo.MixProject do
       releases: [
         release_demo: [
           strip_beams: [keep: ["Docs", "Dbgi"]],
-          applications: [runtime_tools: :permanent]
+          applications: [runtime_tools: :permanent],
+          steps: [:assemble, &copy_app_sources/1]
         ]
       ]
     ]
@@ -24,9 +25,23 @@ defmodule ReleaseDemo.MixProject do
     ]
   end
 
+  # Copy source files into the release so that coverage analysis can read them at runtime.
+  # Without source files, Stats.generate_coverage cannot count lines per file.
+  defp copy_app_sources(release) do
+    release_lib = Path.join(release.path, "lib")
+
+    for {app, src} <- [{:release_demo, "lib"}, {:dep_lib, "../dep_lib/lib"}] do
+      [target] = Path.wildcard(Path.join(release_lib, "#{app}-*"))
+      File.cp_r!(src, Path.join(target, "lib"))
+    end
+
+    release
+  end
+
   defp deps do
     [
-      {:ex_integration_coveralls, path: "../.."}
+      {:ex_integration_coveralls, path: "../.."},
+      {:dep_lib, path: "../dep_lib"}
     ]
   end
 end

--- a/examples/release_demo/smoke_test.sh
+++ b/examples/release_demo/smoke_test.sh
@@ -61,4 +61,64 @@ fi
 echo "PASS: /cov/status returned 200 with status 'already_started'"
 
 echo ""
+echo "=========================================="
+echo "=== Multi-app coverage (dep_apps)      ==="
+echo "=========================================="
+
+echo ""
+echo "=== Step 5: Start coverage with dep_apps ==="
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE_URL/cov/start" \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "release_demo", "dep_apps": ["dep_lib"]}')
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: Expected HTTP 200 but got $HTTP_CODE"
+  exit 1
+fi
+RESPONSE=$(curl -s -X POST "$BASE_URL/cov/start" \
+  -H 'Content-Type: application/json' \
+  -d '{"app_name": "release_demo", "dep_apps": ["dep_lib"]}')
+if [ "$RESPONSE" != "OK" ]; then
+  echo "FAIL: Expected 'OK' but got '$RESPONSE'"
+  exit 1
+fi
+echo "PASS: /cov/start with dep_apps returned 200 with body 'OK'"
+
+echo ""
+echo "=== Step 6: Get total coverage with dep_apps ==="
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/cov/total/release_demo?dep_apps=dep_lib")
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: Expected HTTP 200 but got $HTTP_CODE"
+  exit 1
+fi
+RESPONSE=$(curl -s "$BASE_URL/cov/total/release_demo?dep_apps=dep_lib")
+if ! echo "$RESPONSE" | grep -q '"coverage"'; then
+  echo "FAIL: Response does not contain 'coverage' key: $RESPONSE"
+  exit 1
+fi
+echo "PASS: /cov/total with dep_apps returned 200 with coverage data: $RESPONSE"
+
+echo ""
+echo "=== Step 7: Get coverage report with dep_apps ==="
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/cov/report/release_demo?dep_apps=dep_lib")
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: Expected HTTP 200 but got $HTTP_CODE"
+  exit 1
+fi
+RESPONSE=$(curl -s "$BASE_URL/cov/report/release_demo?dep_apps=dep_lib")
+if ! echo "$RESPONSE" | grep -q '"files"'; then
+  echo "FAIL: Response does not contain 'files' key: $RESPONSE"
+  exit 1
+fi
+# Verify both apps appear in the report
+if ! echo "$RESPONSE" | grep -q 'release_demo'; then
+  echo "FAIL: Report does not contain release_demo files: $RESPONSE"
+  exit 1
+fi
+if ! echo "$RESPONSE" | grep -q 'dep_lib'; then
+  echo "FAIL: Report does not contain dep_lib files: $RESPONSE"
+  exit 1
+fi
+echo "PASS: /cov/report with dep_apps returned 200 with files from both apps"
+
+echo ""
 echo "=== All smoke tests passed! ==="

--- a/examples/release_demo/smoke_test.sh
+++ b/examples/release_demo/smoke_test.sh
@@ -33,6 +33,16 @@ fi
 echo "PASS: /cov/start returned 200 with body 'OK'"
 
 echo ""
+echo "=== Step 2b: Exercise application code to generate non-zero coverage ==="
+# Call business-logic functions via the release's remote_eval to ensure lines are hit.
+RELEASE_BIN="_build/prod/rel/release_demo/bin/release_demo"
+if [ -x "$RELEASE_BIN" ]; then
+  "$RELEASE_BIN" eval 'ReleaseDemo.hello(); ReleaseDemo.add(1,2); ReleaseDemo.greet("world"); ReleaseDemo.square(3)' 2>/dev/null || true
+  "$RELEASE_BIN" eval 'DepLib.multiply(2,3); DepLib.reverse_string("abc"); DepLib.factorial(5)' 2>/dev/null || true
+fi
+echo "PASS: Exercised application code"
+
+echo ""
 echo "=== Step 3: Get coverage data (AC-5) ==="
 HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/cov/total/release_demo")
 if [ "$HTTP_CODE" != "200" ]; then
@@ -44,7 +54,13 @@ if ! echo "$RESPONSE" | grep -q '"coverage"'; then
   echo "FAIL: Response does not contain 'coverage' key: $RESPONSE"
   exit 1
 fi
-echo "PASS: /cov/total/release_demo returned 200 with coverage data: $RESPONSE"
+# Verify coverage is non-zero
+COVERAGE=$(echo "$RESPONSE" | grep -o '"coverage":[0-9.]*' | grep -o '[0-9.]*$')
+if [ -z "$COVERAGE" ] || [ "$COVERAGE" = "0" ]; then
+  echo "FAIL: Expected non-zero coverage but got: $RESPONSE"
+  exit 1
+fi
+echo "PASS: /cov/total/release_demo returned 200 with non-zero coverage ($COVERAGE%): $RESPONSE"
 
 echo ""
 echo "=== Step 4: Check cover status (AC-6) ==="
@@ -84,6 +100,14 @@ fi
 echo "PASS: /cov/start with dep_apps returned 200 with body 'OK'"
 
 echo ""
+echo "=== Step 5b: Exercise code from both apps for non-zero coverage ==="
+if [ -x "$RELEASE_BIN" ]; then
+  "$RELEASE_BIN" eval 'ReleaseDemo.hello(); ReleaseDemo.add(2,3); ReleaseDemo.greet("test"); ReleaseDemo.square(4)' 2>/dev/null || true
+  "$RELEASE_BIN" eval 'DepLib.multiply(3,4); DepLib.reverse_string("hello"); DepLib.factorial(3)' 2>/dev/null || true
+fi
+echo "PASS: Exercised both apps' code"
+
+echo ""
 echo "=== Step 6: Get total coverage with dep_apps ==="
 HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/cov/total/release_demo?dep_apps=dep_lib")
 if [ "$HTTP_CODE" != "200" ]; then
@@ -95,7 +119,13 @@ if ! echo "$RESPONSE" | grep -q '"coverage"'; then
   echo "FAIL: Response does not contain 'coverage' key: $RESPONSE"
   exit 1
 fi
-echo "PASS: /cov/total with dep_apps returned 200 with coverage data: $RESPONSE"
+# Verify multi-app coverage is non-zero
+COVERAGE=$(echo "$RESPONSE" | grep -o '"coverage":[0-9.]*' | grep -o '[0-9.]*$')
+if [ -z "$COVERAGE" ] || [ "$COVERAGE" = "0" ]; then
+  echo "FAIL: Expected non-zero multi-app coverage but got: $RESPONSE"
+  exit 1
+fi
+echo "PASS: /cov/total with dep_apps returned 200 with non-zero coverage ($COVERAGE%): $RESPONSE"
 
 echo ""
 echo "=== Step 7: Get coverage report with dep_apps ==="

--- a/examples/release_demo/smoke_test.sh
+++ b/examples/release_demo/smoke_test.sh
@@ -34,11 +34,12 @@ echo "PASS: /cov/start returned 200 with body 'OK'"
 
 echo ""
 echo "=== Step 2b: Exercise application code to generate non-zero coverage ==="
-# Call business-logic functions via the release's remote_eval to ensure lines are hit.
+# Call business-logic functions on the running release node so the live :cover
+# session records execution counts.
 RELEASE_BIN="_build/prod/rel/release_demo/bin/release_demo"
 if [ -x "$RELEASE_BIN" ]; then
-  "$RELEASE_BIN" eval 'ReleaseDemo.hello(); ReleaseDemo.add(1,2); ReleaseDemo.greet("world"); ReleaseDemo.square(3)' 2>/dev/null || true
-  "$RELEASE_BIN" eval 'DepLib.multiply(2,3); DepLib.reverse_string("abc"); DepLib.factorial(5)' 2>/dev/null || true
+  "$RELEASE_BIN" rpc 'ReleaseDemo.hello(); ReleaseDemo.add(1,2); ReleaseDemo.greet("world"); ReleaseDemo.square(3)' 2>/dev/null || true
+  "$RELEASE_BIN" rpc 'DepLib.multiply(2,3); DepLib.reverse_string("abc"); DepLib.factorial(5)' 2>/dev/null || true
 fi
 echo "PASS: Exercised application code"
 
@@ -102,8 +103,8 @@ echo "PASS: /cov/start with dep_apps returned 200 with body 'OK'"
 echo ""
 echo "=== Step 5b: Exercise code from both apps for non-zero coverage ==="
 if [ -x "$RELEASE_BIN" ]; then
-  "$RELEASE_BIN" eval 'ReleaseDemo.hello(); ReleaseDemo.add(2,3); ReleaseDemo.greet("test"); ReleaseDemo.square(4)' 2>/dev/null || true
-  "$RELEASE_BIN" eval 'DepLib.multiply(3,4); DepLib.reverse_string("hello"); DepLib.factorial(3)' 2>/dev/null || true
+  "$RELEASE_BIN" rpc 'ReleaseDemo.hello(); ReleaseDemo.add(2,3); ReleaseDemo.greet("test"); ReleaseDemo.square(4)' 2>/dev/null || true
+  "$RELEASE_BIN" rpc 'DepLib.multiply(3,4); DepLib.reverse_string("hello"); DepLib.factorial(3)' 2>/dev/null || true
 fi
 echo "PASS: Exercised both apps' code"
 

--- a/lib/cover.ex
+++ b/lib/cover.ex
@@ -5,7 +5,20 @@ defmodule ExIntegrationCoveralls.Cover do
 
   @doc """
   Compile the beam files for coverage analysis.
+  Accepts a single beam directory path or a list of beam directory paths.
   """
+  def compile(compile_paths) when is_list(compile_paths) do
+    :cover.stop()
+    :cover.start()
+
+    Enum.flat_map(compile_paths, fn path ->
+      case :cover.compile_beam_directory(path |> string_to_charlist) do
+        results when is_list(results) -> results
+        error -> [error]
+      end
+    end)
+  end
+
   def compile(compile_path) do
     :cover.stop()
     :cover.start()
@@ -40,8 +53,7 @@ defmodule ExIntegrationCoveralls.Cover do
   Returns the relative file path of the specified module for working directory.
   """
   def module_path(module) do
-    module.module_info(:compile)[:source]
-    |> List.to_string()
+    get_module_source(module)
     |> Path.relative_to(ExIntegrationCoveralls.PathReader.base_path())
   end
 
@@ -49,8 +61,7 @@ defmodule ExIntegrationCoveralls.Cover do
   Returns the relative file path of the specified module for source_lib_absolute_path.
   """
   def module_path(module, source_lib_absolute_path) do
-    module.module_info(:compile)[:source]
-    |> List.to_string()
+    get_module_source(module)
     |> Path.relative_to(source_lib_absolute_path)
   end
 
@@ -65,12 +76,12 @@ defmodule ExIntegrationCoveralls.Cover do
   end
 
   def has_compile_info?(module, module_source_absolute_path \\ "") do
-    with info when not is_nil(info) <- module.module_info(:compile),
-         path when not is_nil(path) <- Keyword.get(info, :source),
-         true <- File.exists?(path) || File.exists?(module_source_absolute_path) do
-      true
-    else
-      _e ->
+    source = get_module_source(module)
+
+    cond do
+      source != nil and File.exists?(source) -> true
+      source != nil and File.exists?(module_source_absolute_path) -> true
+      true ->
         log_missing_source(module)
         false
     end
@@ -80,9 +91,59 @@ defmodule ExIntegrationCoveralls.Cover do
       false
   end
 
+  @doc """
+  Returns modules whose compile-time source path starts with the given root.
+  Used to partition modules by app when multiple apps are instrumented.
+  """
+  def modules_for_compile_root(compile_time_root) do
+    :cover.modules()
+    |> Enum.filter(&module_matches_root?(&1, compile_time_root))
+  end
+
+  defp module_matches_root?(module, compile_time_root) do
+    case get_module_source(module) do
+      nil -> false
+      source -> String.starts_with?(source, compile_time_root)
+    end
+  end
+
   @doc "Wrapper for :cover.analyse https://www.erlang.org/doc/man/cover.html#analyse-3"
   def analyze(module) do
     :cover.analyse(module, :calls, :line)
+  end
+
+  # Returns the compile-time source file path for a module.
+  # First tries module_info(:compile)[:source] (fast path, works in dev/test).
+  # Falls back to reading the beam file's debug_info via :cover.is_compiled/1
+  # (needed in release environments where beams are stripped of compile info).
+  defp get_module_source(module) do
+    case module.module_info(:compile) |> Keyword.get(:source) do
+      path when not is_nil(path) ->
+        List.to_string(path)
+
+      nil ->
+        source_from_cover_beam(module)
+    end
+  rescue
+    _ -> source_from_cover_beam(module)
+  end
+
+  defp source_from_cover_beam(module) do
+    case :cover.is_compiled(module) do
+      {:file, beam_path} ->
+        case :beam_lib.chunks(beam_path, [:debug_info]) do
+          {:ok, {_, [{:debug_info, {:debug_info_v1, _, {_, info, _}}}]}} ->
+            Map.get(info, :file)
+
+          _ ->
+            nil
+        end
+
+      _ ->
+        nil
+    end
+  rescue
+    _ -> nil
   end
 
   if Version.compare(System.version(), "1.3.0") == :lt do

--- a/lib/coverage_ci_poster.ex
+++ b/lib/coverage_ci_poster.ex
@@ -69,6 +69,41 @@ defmodule ExIntegrationCoveralls.CoverageCiPoster do
     Map.put_new(extends, :files, files_map)
   end
 
+  @doc """
+  Post stats from multiple apps to coverage CI.
+
+  ## Parameters
+  - url: CI receive stats address
+  - extends_post_params: use to transform stats which CI service can acceptable form
+  - path_pairs: list of `{compile_time_root, runtime_root}` tuples.
+  """
+  def post_stats_to_cover_ci_multi(url, extends_post_params, path_pairs)
+      when is_list(path_pairs) do
+    stats =
+      get_coverage_stats_multi(path_pairs)
+      |> stats_transformer(extends_post_params)
+
+    body = Json.generate_json_output(stats)
+    Poster.post_to_coverage_services_center(url, body)
+  end
+
+  @doc """
+  Get coverage stats from multiple apps.
+
+  ## Parameters
+  - path_pairs: list of `{compile_time_root, runtime_root}` tuples.
+
+  ## Return
+  A merged list of `{file_path, line_coverage_array}` tuples from all apps.
+  """
+  def get_coverage_stats_multi(path_pairs) when is_list(path_pairs) do
+    Enum.flat_map(path_pairs, fn {compile_time_root, runtime_root} ->
+      Cover.modules_for_compile_root(compile_time_root)
+      |> Stats.calculate_stats(compile_time_root)
+      |> Stats.generate_coverage(runtime_root)
+    end)
+  end
+
   # Return value like this: {"lib/hello.ex", %{ 1 => 3, 2 => 0, 3 => -1}}
   defp file_coverage_map(file_path, line_cov_arr) do
     line_cov_map =

--- a/lib/ex_integration_coveralls.ex
+++ b/lib/ex_integration_coveralls.ex
@@ -12,11 +12,23 @@ defmodule ExIntegrationCoveralls do
 
   ## Parameters
   - app_name: application name, It is a string.
+  - opts: optional keyword list.
+    - dep_apps: list of dependency application name strings to include in coverage.
   """
-  def start_app_cov(app_name) do
-    {_, _, app_beam_dir} = PathReader.get_app_cover_path(app_name)
+  def start_app_cov(app_name, opts \\ []) do
+    dep_apps = Keyword.get(opts, :dep_apps, [])
 
-    execute(app_beam_dir)
+    case dep_apps do
+      [] ->
+        {_, _, app_beam_dir} = PathReader.get_app_cover_path(app_name)
+        execute(app_beam_dir)
+
+      dep_apps when is_list(dep_apps) ->
+        all_app_names = [app_name | dep_apps]
+        all_paths = PathReader.get_apps_cover_paths(all_app_names)
+        beam_dirs = Enum.map(all_paths, fn {_, _, beam_dir} -> beam_dir end)
+        execute(beam_dirs)
+    end
   end
 
   @doc """
@@ -24,12 +36,28 @@ defmodule ExIntegrationCoveralls do
 
   ## Parameters
   - app_name: application name, It is a string.
+  - opts: optional keyword list.
+    - dep_apps: list of dependency application name strings to include in coverage.
   """
-  def get_app_total_cov(app_name) do
-    {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, _} =
-      PathReader.get_app_cover_path(app_name)
+  def get_app_total_cov(app_name, opts \\ []) do
+    dep_apps = Keyword.get(opts, :dep_apps, [])
 
-    get_total_coverage(compile_time_source_lib_abs_path, run_time_source_lib_abs_path)
+    case dep_apps do
+      [] ->
+        {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, _} =
+          PathReader.get_app_cover_path(app_name)
+
+        get_total_coverage(compile_time_source_lib_abs_path, run_time_source_lib_abs_path)
+
+      dep_apps when is_list(dep_apps) ->
+        all_app_names = [app_name | dep_apps]
+        all_paths = PathReader.get_apps_cover_paths(all_app_names)
+
+        path_pairs =
+          Enum.map(all_paths, fn {runtime, compile_time, _} -> {compile_time, runtime} end)
+
+        get_total_coverage_multi(path_pairs)
+    end
   end
 
   @doc """
@@ -39,17 +67,33 @@ defmodule ExIntegrationCoveralls do
   - app_name: application name, It is a string.
   - url: CI receive stats address
   - extends_post_params: use to transform stats which CI service can acceptable form
+  - opts: optional keyword list.
+    - dep_apps: list of dependency application name strings to include in coverage.
   """
-  def post_app_cov_to_ci(url, extends_post_params, app_name) do
-    {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, _} =
-      PathReader.get_app_cover_path(app_name)
+  def post_app_cov_to_ci(url, extends_post_params, app_name, opts \\ []) do
+    dep_apps = Keyword.get(opts, :dep_apps, [])
 
-    post_cov_stats_to_ud_ci(
-      url,
-      extends_post_params,
-      compile_time_source_lib_abs_path,
-      run_time_source_lib_abs_path
-    )
+    case dep_apps do
+      [] ->
+        {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, _} =
+          PathReader.get_app_cover_path(app_name)
+
+        post_cov_stats_to_ud_ci(
+          url,
+          extends_post_params,
+          compile_time_source_lib_abs_path,
+          run_time_source_lib_abs_path
+        )
+
+      dep_apps when is_list(dep_apps) ->
+        all_app_names = [app_name | dep_apps]
+        all_paths = PathReader.get_apps_cover_paths(all_app_names)
+
+        path_pairs =
+          Enum.map(all_paths, fn {runtime, compile_time, _} -> {compile_time, runtime} end)
+
+        CoverageCiPoster.post_stats_to_cover_ci_multi(url, extends_post_params, path_pairs)
+    end
   end
 
   def execute(compiled_beam_dir_path) do
@@ -80,6 +124,23 @@ defmodule ExIntegrationCoveralls do
       |> Stats.report(compile_time_source_lib_abs_path, source_code_abs_path)
       |> Stats.transform_cov()
 
+    Map.get(stats, :coverage)
+  end
+
+  @doc """
+  Get an overall integration test coverage rate across multiple OTP applications.
+
+  ## Parameters
+  - path_pairs: list of `{compile_time_root, runtime_root}` tuples.
+  """
+  def get_total_coverage_multi(path_pairs) when is_list(path_pairs) do
+    all_source_info =
+      Enum.flat_map(path_pairs, fn {compile_time_root, runtime_root} ->
+        Cover.modules_for_compile_root(compile_time_root)
+        |> Stats.report(compile_time_root, runtime_root)
+      end)
+
+    stats = Stats.transform_cov(all_source_info)
     Map.get(stats, :coverage)
   end
 
@@ -125,6 +186,22 @@ defmodule ExIntegrationCoveralls do
       |> Stats.transform_cov()
 
     stats
+  end
+
+  @doc """
+  Get an overall integration test coverage analysis report across multiple OTP applications.
+
+  ## Parameters
+  - path_pairs: list of `{compile_time_root, runtime_root}` tuples.
+  """
+  def get_coverage_report_multi(path_pairs) when is_list(path_pairs) do
+    all_source_info =
+      Enum.flat_map(path_pairs, fn {compile_time_root, runtime_root} ->
+        Cover.modules_for_compile_root(compile_time_root)
+        |> Stats.report(compile_time_root, runtime_root)
+      end)
+
+    Stats.transform_cov(all_source_info)
   end
 
   @doc """

--- a/lib/ex_integration_coveralls/cov_stats_router.ex
+++ b/lib/ex_integration_coveralls/cov_stats_router.ex
@@ -22,10 +22,12 @@ defmodule ExIntegrationCoveralls.CovStatsRouter do
       case conn.body_params do
         %{"app_name" => app_name} ->
           use_async = Map.get(conn.body_params, "use_async", false)
+          dep_apps = Map.get(conn.body_params, "dep_apps", [])
+          opts = build_opts(dep_apps)
 
           case use_async do
-            true -> {200, GenServer.cast(CovStatsWorker, {:start_cov, app_name})}
-            _ -> {200, ExIntegrationCoveralls.start_app_cov(app_name)}
+            true -> {200, GenServer.cast(CovStatsWorker, {:start_cov, app_name, opts})}
+            _ -> {200, ExIntegrationCoveralls.start_app_cov(app_name, opts)}
           end
 
         _ ->
@@ -36,7 +38,11 @@ defmodule ExIntegrationCoveralls.CovStatsRouter do
   end
 
   get "/cov/total/:app_name" do
-    total_cov = ExIntegrationCoveralls.get_app_total_cov(app_name)
+    conn = Plug.Conn.fetch_query_params(conn)
+    dep_apps = parse_dep_apps_query(conn)
+    opts = build_opts(dep_apps)
+
+    total_cov = ExIntegrationCoveralls.get_app_total_cov(app_name, opts)
 
     body =
       Json.generate_json_output(%{
@@ -58,15 +64,31 @@ defmodule ExIntegrationCoveralls.CovStatsRouter do
   end
 
   get "/cov/report/:app_name" do
-    {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, _} =
-      PathReader.get_app_cover_path(app_name)
+    conn = Plug.Conn.fetch_query_params(conn)
+    dep_apps = parse_dep_apps_query(conn)
 
     stats =
-      CoverageCiPoster.get_coverage_stats(
-        compile_time_source_lib_abs_path,
-        run_time_source_lib_abs_path
-      )
-      |> CoverageCiPoster.stats_transformer()
+      case dep_apps do
+        [] ->
+          {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, _} =
+            PathReader.get_app_cover_path(app_name)
+
+          CoverageCiPoster.get_coverage_stats(
+            compile_time_source_lib_abs_path,
+            run_time_source_lib_abs_path
+          )
+          |> CoverageCiPoster.stats_transformer()
+
+        dep_apps when is_list(dep_apps) ->
+          all_app_names = [app_name | dep_apps]
+          all_paths = PathReader.get_apps_cover_paths(all_app_names)
+
+          path_pairs =
+            Enum.map(all_paths, fn {runtime, compile_time, _} -> {compile_time, runtime} end)
+
+          CoverageCiPoster.get_coverage_stats_multi(path_pairs)
+          |> CoverageCiPoster.stats_transformer()
+      end
 
     body = Json.generate_json_output(stats)
     send_resp(conn, 200, body)
@@ -77,7 +99,9 @@ defmodule ExIntegrationCoveralls.CovStatsRouter do
     {status, _} =
       case conn.body_params do
         %{"app_name" => app_name, "extend_params" => extend_params, "url" => url} ->
-          {200, ExIntegrationCoveralls.post_app_cov_to_ci(url, extend_params, app_name)}
+          dep_apps = Map.get(conn.body_params, "dep_apps", [])
+          opts = build_opts(dep_apps)
+          {200, ExIntegrationCoveralls.post_app_cov_to_ci(url, extend_params, app_name, opts)}
 
         _ ->
           {400, "bad request!"}
@@ -113,4 +137,17 @@ defmodule ExIntegrationCoveralls.CovStatsRouter do
   match _ do
     send_resp(conn, 404, "unknown route!")
   end
+
+  defp parse_dep_apps_query(conn) do
+    case conn.query_params do
+      %{"dep_apps" => dep_apps_str} when is_binary(dep_apps_str) ->
+        dep_apps_str |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+
+      _ ->
+        []
+    end
+  end
+
+  defp build_opts([]), do: []
+  defp build_opts(dep_apps) when is_list(dep_apps), do: [dep_apps: dep_apps]
 end

--- a/lib/ex_integration_coveralls/cov_stats_worker.ex
+++ b/lib/ex_integration_coveralls/cov_stats_worker.ex
@@ -18,6 +18,12 @@ defmodule ExIntegrationCoveralls.CovStatsWorker do
   end
 
   @impl true
+  def handle_call({:start_cov, app_name, opts}, _from, state) do
+    result = ExIntegrationCoveralls.start_app_cov(app_name, opts)
+    {:reply, result, Map.put(state, :app_name, app_name)}
+  end
+
+  @impl true
   def handle_call({:stop_cov}, _from, state) do
     status = ExIntegrationCoveralls.exit()
     {:reply, status, state}
@@ -27,15 +33,38 @@ defmodule ExIntegrationCoveralls.CovStatsWorker do
   def handle_cast({:start_cov, app_name}, state) do
     ExIntegrationCoveralls.start_app_cov(app_name)
     {:noreply, Map.put(state, :app_name, app_name)}
+  rescue
+    e ->
+      require Logger
+      Logger.error("CovStatsWorker start_cov failed: #{inspect(e)}")
+      {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:start_cov, app_name, opts}, state) do
+    ExIntegrationCoveralls.start_app_cov(app_name, opts)
+    {:noreply, Map.put(state, :app_name, app_name)}
+  rescue
+    e ->
+      require Logger
+      Logger.error("CovStatsWorker start_cov failed: #{inspect(e)}")
+      {:noreply, state}
   end
 
   @impl true
   def handle_cast(
         {:start_cov_push,
-         %{"app_name" => app_name, "extend_params" => extend_params, "url" => url}},
+         %{"app_name" => app_name, "extend_params" => extend_params, "url" => url} = params},
         state
       ) do
-    ExIntegrationCoveralls.post_app_cov_to_ci(url, extend_params, app_name)
+    dep_apps = Map.get(params, "dep_apps", [])
+    opts = if dep_apps == [], do: [], else: [dep_apps: dep_apps]
+    ExIntegrationCoveralls.post_app_cov_to_ci(url, extend_params, app_name, opts)
     {:noreply, Map.put(state, :app_name, app_name)}
+  rescue
+    e ->
+      require Logger
+      Logger.error("CovStatsWorker start_cov_push failed: #{inspect(e)}")
+      {:noreply, state}
   end
 end

--- a/lib/path_reader.ex
+++ b/lib/path_reader.ex
@@ -52,6 +52,19 @@ defmodule ExIntegrationCoveralls.PathReader do
   end
 
   @doc """
+  Get application cover paths for multiple apps.
+
+  ## Parameters
+  - app_names: a list of application name strings.
+
+  ## Returns
+  A list of `{app_dir, compile_time_source_lib_abs_path, app_beam_dir}` tuples.
+  """
+  def get_apps_cover_paths(app_names) when is_list(app_names) do
+    Enum.map(app_names, &get_app_cover_path/1)
+  end
+
+  @doc """
   Get git commit id. Can be used to compare with previous coverage results (last commit).
   """
   def get_commit_id_and_branch_from_file(path) do

--- a/test/cover_test.exs
+++ b/test/cover_test.exs
@@ -194,11 +194,8 @@ defmodule ExIntegrationCoveralls.CoverTest do
     Cover.stop()
   end
 
-  test "modules_for_compile_root with no cover modules returns empty" do
-    # When no modules are compiled by cover, should return empty list
-    :cover.stop()
-    :cover.start()
-    assert Cover.modules_for_compile_root("/any/root") == []
-    :cover.stop()
+  test "modules_for_compile_root with unmatched root returns empty" do
+    # A root that does not match any compiled module's source path should return []
+    assert Cover.modules_for_compile_root("/no/such/root/exists/here") == []
   end
 end

--- a/test/cover_test.exs
+++ b/test/cover_test.exs
@@ -86,24 +86,17 @@ defmodule ExIntegrationCoveralls.CoverTest do
   test "get cover analyst, compiled module by cover" do
     _cover_modules = Cover.compile(PathReader.expand_path(@beam_file_path))
 
-    expect =
-      {:ok,
-       [
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 0}, 0},
-         {{Hello, 16}, 0},
-         {{Hello, 18}, 0},
-         {{Hello, 20}, 0}
-       ]}
+    {:ok, lines} = Cover.analyze(Hello)
 
-    assert(Cover.analyze(Hello) == expect)
+    # The number of zero-line entries varies by OTP version, so only check
+    # that the specific executable lines are present.
+    specific_lines = Enum.filter(lines, fn {{_mod, line}, _count} -> line > 0 end)
+
+    assert(specific_lines == [
+      {{Hello, 16}, 0},
+      {{Hello, 18}, 0},
+      {{Hello, 20}, 0}
+    ])
   end
 
   test "has_compile_info?/1 with uncompiled module raises warning and returns false" do
@@ -151,5 +144,32 @@ defmodule ExIntegrationCoveralls.CoverTest do
 
   test "has_compile_info?/1 with existing source returns true" do
     assert(Cover.has_compile_info?(TestMissing))
+  end
+
+  @tag :real_cover
+  test "compile with list of beam dirs" do
+    result = Cover.compile([PathReader.expand_path(@beam_file_path)])
+    assert(result == [ok: Hello])
+    Cover.stop()
+  end
+
+  @tag :real_cover
+  test "compile with empty list" do
+    result = Cover.compile([])
+    assert(result == [])
+    Cover.stop()
+  end
+
+  @tag :real_cover
+  test "modules_for_compile_root filters by compile-time root" do
+    _cover_modules = Cover.compile(PathReader.expand_path(@beam_file_path))
+
+    # The Hello module was compiled at /private/tmp/hello
+    assert(Cover.modules_for_compile_root("/private/tmp/hello") == [Hello])
+
+    # A non-matching root should return empty
+    assert(Cover.modules_for_compile_root("/nonexistent/root") == [])
+
+    Cover.stop()
   end
 end

--- a/test/cover_test.exs
+++ b/test/cover_test.exs
@@ -172,4 +172,33 @@ defmodule ExIntegrationCoveralls.CoverTest do
 
     Cover.stop()
   end
+
+  @tag :real_cover
+  test "has_compile_info?/2 with valid module and matching path returns true" do
+    _cover_modules = Cover.compile(PathReader.expand_path(@beam_file_path))
+
+    source_path =
+      ExIntegrationCoveralls.PathReader.base_path() <>
+        "/" <>
+        @source_file_path
+
+    assert Cover.has_compile_info?(Hello, source_path)
+    Cover.stop()
+  end
+
+  @tag :real_cover
+  test "compile with single path returns list" do
+    result = Cover.compile(PathReader.expand_path(@beam_file_path))
+    assert is_list(result)
+    assert {:ok, Hello} in result
+    Cover.stop()
+  end
+
+  test "modules_for_compile_root with no cover modules returns empty" do
+    # When no modules are compiled by cover, should return empty list
+    :cover.stop()
+    :cover.start()
+    assert Cover.modules_for_compile_root("/any/root") == []
+    :cover.stop()
+  end
 end

--- a/test/coverage_ci_poster_test.exs
+++ b/test/coverage_ci_poster_test.exs
@@ -1,6 +1,7 @@
 defmodule ExIntegrationCoveralls.CoverageCiPosterTest do
   use ExUnit.Case, async: false
   import Mock
+  alias ExIntegrationCoveralls.Cover
   alias ExIntegrationCoveralls.Stats
   alias ExIntegrationCoveralls.Poster
   alias ExIntegrationCoveralls.PathReader
@@ -72,6 +73,49 @@ defmodule ExIntegrationCoveralls.CoverageCiPosterTest do
           @extends_params,
           @compile_time_source_lib_abs_path,
           @source_code_abs_path
+        ) == @response
+      )
+    end
+  end
+
+  test "get coverage stats multi" do
+    with_mocks([
+      {Cover, [], [modules_for_compile_root: fn _ -> [Hello] end]},
+      {Stats, [],
+       [
+         calculate_stats: fn _, _ -> @calc_stats end,
+         generate_coverage: fn _, _ -> @cov_stats end
+       ]}
+    ]) do
+      path_pairs = [
+        {@compile_time_source_lib_abs_path, @source_code_abs_path}
+      ]
+
+      assert(CoverageCiPoster.get_coverage_stats_multi(path_pairs) == @cov_stats)
+    end
+  end
+
+  test "post stats to cover ci service multi" do
+    with_mocks([
+      {Cover, [], [modules_for_compile_root: fn _ -> [Hello] end]},
+      {Stats, [],
+       [
+         calculate_stats: fn _, _ -> @calc_stats end,
+         generate_coverage: fn _, _ -> @cov_stats end
+       ]},
+      {Poster, [], [post_to_coverage_services_center: fn _, _ -> @response end]}
+    ]) do
+      url = "https://github.com"
+
+      path_pairs = [
+        {@compile_time_source_lib_abs_path, @source_code_abs_path}
+      ]
+
+      assert(
+        CoverageCiPoster.post_stats_to_cover_ci_multi(
+          url,
+          @extends_params,
+          path_pairs
         ) == @response
       )
     end

--- a/test/ex_integration_coveralls/application_test.exs
+++ b/test/ex_integration_coveralls/application_test.exs
@@ -1,0 +1,27 @@
+defmodule ExIntegrationCoveralls.ApplicationTest do
+  use ExUnit.Case, async: false
+  alias ExIntegrationCoveralls.Application, as: App
+
+  test "is_use_cov_worker?/0 returns configured value" do
+    # Default is true
+    assert App.is_use_cov_worker?() == true
+  end
+
+  test "is_use_cov_worker?/0 respects config" do
+    original = Application.get_env(:cov_worker, :enable_cov_worker)
+
+    on_exit(fn ->
+      if original == nil do
+        Application.delete_env(:cov_worker, :enable_cov_worker)
+      else
+        Application.put_env(:cov_worker, :enable_cov_worker, original)
+      end
+    end)
+
+    Application.put_env(:cov_worker, :enable_cov_worker, false)
+    refute App.is_use_cov_worker?()
+
+    Application.put_env(:cov_worker, :enable_cov_worker, true)
+    assert App.is_use_cov_worker?()
+  end
+end

--- a/test/ex_integration_coveralls/cov_stats_router_test.exs
+++ b/test/ex_integration_coveralls/cov_stats_router_test.exs
@@ -323,6 +323,53 @@ defmodule ExIntegrationCoveralls.CovStatsRouterTest do
     end
   end
 
+  describe "cov start bad request" do
+    test "missing app_name returns 400" do
+      conn =
+        :post
+        |> conn("/cov/start", %{:foo => "bar"})
+        |> CovStatsRouter.call(@opts)
+
+      assert conn.state == :sent
+      assert conn.status == 400
+    end
+  end
+
+  describe "cov push trigger with dep_apps" do
+    test_with_mock "foo app push with deps", ExIntegrationCoveralls,
+      post_app_cov_to_ci: fn _, _, _, _ -> @response end do
+      url = "https://github.com"
+
+      conn =
+        :post
+        |> conn("/cov/push_trigger", %{
+          :app_name => "foo",
+          :extend_params => @extends_params,
+          :url => url,
+          :dep_apps => ["bar"]
+        })
+        |> CovStatsRouter.call(@opts)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "OK"
+    end
+  end
+
+  describe "total coverage without dep_apps query param" do
+    test_with_mock "foo app total cov with empty dep_apps", ExIntegrationCoveralls,
+      get_app_total_cov: fn _, _ -> 60 end do
+      conn =
+        :get
+        |> conn("/cov/total/foo?other_param=value", "")
+        |> CovStatsRouter.call(@opts)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "{\"coverage\":60}"
+    end
+  end
+
   test "unknown route" do
     conn =
       :get

--- a/test/ex_integration_coveralls/cov_stats_router_test.exs
+++ b/test/ex_integration_coveralls/cov_stats_router_test.exs
@@ -62,7 +62,7 @@ defmodule ExIntegrationCoveralls.CovStatsRouterTest do
       end
     end
 
-    test_with_mock "foo app", ExIntegrationCoveralls, start_app_cov: fn _ -> [ok: Foo] end do
+    test_with_mock "foo app", ExIntegrationCoveralls, start_app_cov: fn _, _ -> [ok: Foo] end do
       conn =
         :post
         |> conn("/cov/start", %{:app_name => "foo"})
@@ -73,7 +73,8 @@ defmodule ExIntegrationCoveralls.CovStatsRouterTest do
       assert conn.resp_body == "OK"
     end
 
-    test_with_mock "foo app async", ExIntegrationCoveralls, start_app_cov: fn _ -> [ok: Foo] end do
+    test_with_mock "foo app async", ExIntegrationCoveralls,
+      start_app_cov: fn _, _ -> [ok: Foo] end do
       conn =
         :post
         |> conn("/cov/start", %{:app_name => "foo", :use_async => true})
@@ -94,7 +95,8 @@ defmodule ExIntegrationCoveralls.CovStatsRouterTest do
       end
     end
 
-    test_with_mock "foo app total cov", ExIntegrationCoveralls, get_app_total_cov: fn _ -> 50 end do
+    test_with_mock "foo app total cov", ExIntegrationCoveralls,
+      get_app_total_cov: fn _, _ -> 50 end do
       conn =
         :get
         |> conn("/cov/total/foo", "")
@@ -173,7 +175,7 @@ defmodule ExIntegrationCoveralls.CovStatsRouterTest do
     end
 
     test_with_mock "foo app", ExIntegrationCoveralls,
-      post_app_cov_to_ci: fn _, _, _ -> @response end do
+      post_app_cov_to_ci: fn _, _, _, _ -> @response end do
       url = "https://github.com"
 
       conn =
@@ -223,6 +225,101 @@ defmodule ExIntegrationCoveralls.CovStatsRouterTest do
                  "{\"commit_id\":\"702c1d15e59d87707dbd4676960238efc598f740\",\"branch\":\"main\",\"app_name\":\"foo\"}"
                  |> Jason.decode!()
       end
+    end
+  end
+
+  describe "cov start with dep_apps" do
+    test_with_mock "foo app with deps", ExIntegrationCoveralls,
+      start_app_cov: fn _, _ -> [ok: Foo, ok: Bar] end do
+      conn =
+        :post
+        |> conn("/cov/start", %{:app_name => "foo", :dep_apps => ["bar"]})
+        |> CovStatsRouter.call(@opts)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "OK"
+    end
+
+    test_with_mock "foo app with deps async", ExIntegrationCoveralls,
+      start_app_cov: fn _, _ -> [ok: Foo, ok: Bar] end do
+      conn =
+        :post
+        |> conn("/cov/start", %{
+          :app_name => "foo",
+          :dep_apps => ["bar"],
+          :use_async => true
+        })
+        |> CovStatsRouter.call(@opts)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "OK"
+    end
+  end
+
+  describe "total coverage with dep_apps" do
+    test_with_mock "foo app total cov with deps", ExIntegrationCoveralls,
+      get_app_total_cov: fn _, _ -> 75 end do
+      conn =
+        :get
+        |> conn("/cov/total/foo?dep_apps=bar,baz", "")
+        |> CovStatsRouter.call(@opts)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "{\"coverage\":75}"
+    end
+  end
+
+  describe "cov report with dep_apps" do
+    test "foo app cov report with deps" do
+      with_mocks([
+        {CoverageCiPoster, [],
+         [
+           get_coverage_stats_multi: fn _ -> @cov_stats end,
+           stats_transformer: fn _ -> @transform_stats end
+         ]},
+        {PathReader, [],
+         [
+           get_apps_cover_paths: fn _ ->
+             [
+               {"compile_path1", "run_time_path1", "app_dir1"},
+               {"compile_path2", "run_time_path2", "app_dir2"}
+             ]
+           end
+         ]}
+      ]) do
+        conn =
+          :get
+          |> conn("/cov/report/foo?dep_apps=bar", "")
+          |> CovStatsRouter.call(@opts)
+
+        assert conn.state == :sent
+        assert conn.status == 200
+        assert conn.resp_body == @report
+      end
+    end
+  end
+
+  describe "cov push trigger with dep_apps" do
+    test_with_mock "foo app with deps", ExIntegrationCoveralls,
+      post_app_cov_to_ci: fn _, _, _, _ -> @response end do
+      url = "https://github.com"
+
+      conn =
+        :post
+        |> conn("/cov/push_trigger", %{
+          :app_name => "foo",
+          :extend_params => @extends_params,
+          :url => url,
+          :dep_apps => ["bar"]
+        })
+        |> CovStatsRouter.call(@opts)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "OK"
     end
   end
 

--- a/test/ex_integration_coveralls/cov_stats_router_test.exs
+++ b/test/ex_integration_coveralls/cov_stats_router_test.exs
@@ -335,27 +335,6 @@ defmodule ExIntegrationCoveralls.CovStatsRouterTest do
     end
   end
 
-  describe "cov push trigger with dep_apps" do
-    test_with_mock "foo app push with deps", ExIntegrationCoveralls,
-      post_app_cov_to_ci: fn _, _, _, _ -> @response end do
-      url = "https://github.com"
-
-      conn =
-        :post
-        |> conn("/cov/push_trigger", %{
-          :app_name => "foo",
-          :extend_params => @extends_params,
-          :url => url,
-          :dep_apps => ["bar"]
-        })
-        |> CovStatsRouter.call(@opts)
-
-      assert conn.state == :sent
-      assert conn.status == 200
-      assert conn.resp_body == "OK"
-    end
-  end
-
   describe "total coverage without dep_apps query param" do
     test_with_mock "foo app total cov with empty dep_apps", ExIntegrationCoveralls,
       get_app_total_cov: fn _, _ -> 60 end do

--- a/test/ex_integration_coveralls/cov_stats_worker_test.exs
+++ b/test/ex_integration_coveralls/cov_stats_worker_test.exs
@@ -25,6 +25,19 @@ defmodule ExIntegrationCoveralls.CovStatsWorkerTest do
     :ok
   end
 
+  setup do
+    # Ensure the CovStatsWorker is running.
+    # It may have crashed from async cast tests (router tests send casts
+    # that are processed after mock teardown, crashing the GenServer).
+    # If the supervisor exceeded max_restarts, the whole app shuts down.
+    unless Process.whereis(CovStatsWorker) do
+      Application.stop(:ex_integration_coveralls)
+      Application.ensure_all_started(:ex_integration_coveralls)
+    end
+
+    :ok
+  end
+
   describe "start app cov" do
     test "call" do
       with_mocks([
@@ -73,7 +86,7 @@ defmodule ExIntegrationCoveralls.CovStatsWorkerTest do
   end
 
   test_with_mock "app cov push to coverage ci", ExIntegrationCoveralls,
-    post_app_cov_to_ci: fn _, _, _ -> @response end do
+    post_app_cov_to_ci: fn _, _, _, _ -> @response end do
     pid = Process.whereis(CovStatsWorker)
 
     app_name = "explore_ast_app"
@@ -85,6 +98,61 @@ defmodule ExIntegrationCoveralls.CovStatsWorkerTest do
         pid,
         {:start_cov_push,
          %{"app_name" => app_name, "extend_params" => extend_params, "url" => url}}
+      )
+
+    assert(result == :ok)
+  end
+
+  describe "start app cov with dep_apps" do
+    test "call with opts" do
+      with_mocks([
+        {ExIntegrationCoveralls, [],
+         [
+           start_app_cov: fn _, _ -> [ok: Hello, ok: Dep1] end
+         ]},
+        {Application, [], [app_dir: fn _ -> PathReader.expand_path(@application_dir) end]}
+      ]) do
+        pid = Process.whereis(CovStatsWorker)
+
+        result = GenServer.call(pid, {:start_cov, "explore_ast_app", [dep_apps: ["dep1"]]})
+        assert(result == [ok: Hello, ok: Dep1])
+      end
+    end
+
+    test "cast with opts" do
+      with_mocks([
+        {ExIntegrationCoveralls, [],
+         [
+           start_app_cov: fn _, _ -> [ok: Hello, ok: Dep1] end
+         ]},
+        {Application, [], [app_dir: fn _ -> PathReader.expand_path(@application_dir) end]}
+      ]) do
+        pid = Process.whereis(CovStatsWorker)
+
+        result = GenServer.cast(pid, {:start_cov, "explore_ast_app", [dep_apps: ["dep1"]]})
+        assert(result == :ok)
+      end
+    end
+  end
+
+  test_with_mock "app cov push to coverage ci with dep_apps", ExIntegrationCoveralls,
+    post_app_cov_to_ci: fn _, _, _, _ -> @response end do
+    pid = Process.whereis(CovStatsWorker)
+
+    app_name = "explore_ast_app"
+    extend_params = %{}
+    url = "https://github.com"
+
+    result =
+      GenServer.cast(
+        pid,
+        {:start_cov_push,
+         %{
+           "app_name" => app_name,
+           "extend_params" => extend_params,
+           "url" => url,
+           "dep_apps" => ["dep1"]
+         }}
       )
 
     assert(result == :ok)

--- a/test/ex_integration_coveralls_test.exs
+++ b/test/ex_integration_coveralls_test.exs
@@ -254,4 +254,43 @@ defmodule ExIntegrationCoverallsTest do
       )
     end
   end
+
+  test "get app coverage report (get_coverage_report) with dep_apps" do
+    with_mocks([
+      {PathReader, [],
+       [
+         get_apps_cover_paths: fn _ ->
+           [
+             @run_time_env_cov_path,
+             @run_time_env_cov_path
+           ]
+         end
+       ]},
+      {Cover, [],
+       [modules_for_compile_root: fn _ -> [Hello] end]},
+      {Stats, [],
+       [
+         transform_cov: fn _ -> @source_transform_cov_result end,
+         report: fn _, _, _ -> @stats_report end
+       ]}
+    ]) do
+      # The get_app_coverage_report function is accessed via get_coverage_report_multi
+      path_pairs = [
+        {@compile_time_source_lib_abs_path, @application_dir},
+        {@compile_time_source_lib_abs_path, @application_dir}
+      ]
+
+      result = ExIntegrationCoveralls.get_coverage_report_multi(path_pairs)
+      assert result == @source_transform_cov_result
+    end
+  end
+
+  test_with_mock "post cov stats to ud ci", CoverageCiPoster,
+    post_stats_to_cover_ci: fn _, _, _, _ -> @response end do
+    url = "https://github.com"
+
+    assert(
+      ExIntegrationCoveralls.post_cov_stats_to_ud_ci(url, @extends_params) == @response
+    )
+  end
 end

--- a/test/ex_integration_coveralls_test.exs
+++ b/test/ex_integration_coveralls_test.exs
@@ -141,4 +141,117 @@ defmodule ExIntegrationCoverallsTest do
     transform_cov: fn _ -> @source_transform_cov_result end do
     assert(ExIntegrationCoveralls.get_coverage_report() == @source_transform_cov_result)
   end
+
+  test "start app cov with dep_apps" do
+    with_mocks([
+      {PathReader, [],
+       [
+         get_apps_cover_paths: fn _ ->
+           [
+             @run_time_env_cov_path,
+             @run_time_env_cov_path
+           ]
+         end
+       ]},
+      {Cover, [], [compile: fn _ -> [ok: Hello, ok: Dep1] end]}
+    ]) do
+      result =
+        ExIntegrationCoveralls.start_app_cov("hello", dep_apps: ["dep1"])
+
+      assert(result == [ok: Hello, ok: Dep1])
+    end
+  end
+
+  test "get app total cov with dep_apps" do
+    with_mocks([
+      {PathReader, [],
+       [
+         get_apps_cover_paths: fn _ ->
+           [
+             @run_time_env_cov_path,
+             @run_time_env_cov_path
+           ]
+         end
+       ]},
+      {Cover, [],
+       [modules_for_compile_root: fn _ -> [Hello] end]},
+      {Stats, [],
+       [
+         transform_cov: fn _ -> @source_transform_cov_result end,
+         report: fn _, _, _ -> @stats_report end
+       ]}
+    ]) do
+      assert(
+        ExIntegrationCoveralls.get_app_total_cov("hello", dep_apps: ["dep1"]) == 50
+      )
+    end
+  end
+
+  test "post app cov to ci with dep_apps" do
+    with_mocks([
+      {PathReader, [],
+       [
+         get_apps_cover_paths: fn _ ->
+           [
+             @run_time_env_cov_path,
+             @run_time_env_cov_path
+           ]
+         end
+       ]},
+      {CoverageCiPoster, [],
+       [
+         post_stats_to_cover_ci_multi: fn _, _, _ -> @response end
+       ]}
+    ]) do
+      url = "https://github.com"
+
+      assert(
+        ExIntegrationCoveralls.post_app_cov_to_ci(
+          url,
+          @extends_params,
+          "hello",
+          dep_apps: ["dep1"]
+        ) == @response
+      )
+    end
+  end
+
+  test "get total coverage multi" do
+    with_mocks([
+      {Cover, [],
+       [modules_for_compile_root: fn _ -> [Hello] end]},
+      {Stats, [],
+       [
+         transform_cov: fn _ -> @source_transform_cov_result end,
+         report: fn _, _, _ -> @stats_report end
+       ]}
+    ]) do
+      path_pairs = [
+        {@compile_time_source_lib_abs_path, @application_dir}
+      ]
+
+      assert(ExIntegrationCoveralls.get_total_coverage_multi(path_pairs) == 50)
+    end
+  end
+
+  test "get coverage report multi" do
+    with_mocks([
+      {Cover, [],
+       [modules_for_compile_root: fn _ -> [Hello] end]},
+      {Stats, [],
+       [
+         transform_cov: fn _ -> @source_transform_cov_result end,
+         report: fn _, _, _ -> @stats_report end
+       ]}
+    ]) do
+      path_pairs = [
+        {@compile_time_source_lib_abs_path, @application_dir}
+      ]
+
+      assert(
+        ExIntegrationCoveralls.get_coverage_report_multi(path_pairs) ==
+          @source_transform_cov_result
+      )
+    end
+  end
 end

--- a/test/multi_app_e2e_test.exs
+++ b/test/multi_app_e2e_test.exs
@@ -1,0 +1,201 @@
+defmodule ExIntegrationCoveralls.MultiAppE2ETest do
+  @moduledoc """
+  End-to-end tests for multi-app coverage collection.
+  These tests use the real :cover module — no mocks.
+  """
+  use ExUnit.Case, async: false
+
+  alias ExIntegrationCoveralls.Cover
+  alias ExIntegrationCoveralls.Stats
+  alias ExIntegrationCoveralls.CoverageCiPoster
+  alias ExIntegrationCoveralls.PathReader
+
+  @moduletag :real_cover
+
+  @hello_beam_dir PathReader.expand_path("test/fixtures/hello/ebin")
+  @hello_compile_root "/private/tmp/hello"
+  @hello_runtime_root PathReader.expand_path("test/fixtures/hello")
+
+  # Call Hello.hello/0 without triggering compile-time "undefined module" warning.
+  # The Hello module is loaded at runtime via :cover.compile_beam_directory.
+  defp call_hello, do: apply(Hello, :hello, [])
+
+  setup do
+    on_exit(fn -> Cover.stop() end)
+
+    project_ebin = Application.app_dir(:ex_integration_coveralls, "ebin")
+    project_root = File.cwd!()
+
+    {:ok, project_ebin: project_ebin, project_root: project_root}
+  end
+
+  describe "multi-dir compilation" do
+    test "compiles modules from both beam directories", ctx do
+      result = Cover.compile([@hello_beam_dir, ctx.project_ebin])
+
+      assert is_list(result)
+      assert {:ok, Hello} in result
+
+      # At least one project module is compiled
+      project_modules =
+        Enum.filter(result, fn
+          {:ok, mod} -> mod != Hello and String.starts_with?(Atom.to_string(mod), "Elixir.ExIntegrationCoveralls")
+          _ -> false
+        end)
+
+      assert length(project_modules) > 0
+
+      # No errors
+      errors = Enum.filter(result, fn {:ok, _} -> false; _ -> true end)
+      assert errors == []
+    end
+  end
+
+  describe "modules_for_compile_root/1 partitioning" do
+    test "correctly separates modules by compile-time root", ctx do
+      Cover.compile([@hello_beam_dir, ctx.project_ebin])
+
+      hello_modules = Cover.modules_for_compile_root(@hello_compile_root)
+      assert hello_modules == [Hello]
+
+      project_modules = Cover.modules_for_compile_root(ctx.project_root)
+      assert length(project_modules) > 0
+      refute Hello in project_modules
+
+      # Two sets are disjoint
+      hello_set = MapSet.new(hello_modules)
+      project_set = MapSet.new(project_modules)
+      assert MapSet.disjoint?(hello_set, project_set)
+    end
+  end
+
+  describe "per-app stats collection after code execution" do
+    test "coverage data respects partitioning", ctx do
+      Cover.compile([@hello_beam_dir, ctx.project_ebin])
+      call_hello()
+
+      # Hello partition: line 16 was executed
+      hello_modules = Cover.modules_for_compile_root(@hello_compile_root)
+      hello_stats = Stats.calculate_stats(hello_modules, @hello_compile_root)
+      assert Map.has_key?(hello_stats, "lib/hello.ex")
+      assert hello_stats["lib/hello.ex"][16] > 0
+
+      # Project partition: does NOT contain "lib/hello.ex"
+      project_modules = Cover.modules_for_compile_root(ctx.project_root)
+      project_stats = Stats.calculate_stats(project_modules, ctx.project_root)
+      assert map_size(project_stats) > 0
+      refute Map.has_key?(project_stats, "lib/hello.ex")
+    end
+  end
+
+  describe "get_total_coverage_multi/1" do
+    test "returns merged coverage percentage from multiple apps", ctx do
+      Cover.compile([@hello_beam_dir, ctx.project_ebin])
+      call_hello()
+
+      path_pairs = [
+        {@hello_compile_root, @hello_runtime_root},
+        {ctx.project_root, ctx.project_root}
+      ]
+
+      result = ExIntegrationCoveralls.get_total_coverage_multi(path_pairs)
+      assert is_number(result)
+      assert result >= 0 and result <= 100
+      # Hello is 100% covered, so total > 0
+      assert result > 0
+    end
+  end
+
+  describe "get_coverage_report_multi/1" do
+    test "report contains files from both apps with correct structure", ctx do
+      Cover.compile([@hello_beam_dir, ctx.project_ebin])
+      call_hello()
+
+      path_pairs = [
+        {@hello_compile_root, @hello_runtime_root},
+        {ctx.project_root, ctx.project_root}
+      ]
+
+      report = ExIntegrationCoveralls.get_coverage_report_multi(path_pairs)
+
+      assert is_map(report)
+      assert Map.has_key?(report, :coverage)
+      assert Map.has_key?(report, :sloc)
+      assert Map.has_key?(report, :hits)
+      assert Map.has_key?(report, :misses)
+      assert Map.has_key?(report, :files)
+
+      filenames = Enum.map(report.files, & &1.filename)
+      assert "lib/hello.ex" in filenames
+
+      # Project files are also present
+      project_files = Enum.filter(filenames, fn f -> f != "lib/hello.ex" end)
+      assert length(project_files) > 0
+
+      # Hello module has 100% coverage (all 3 executable lines hit)
+      hello_file = Enum.find(report.files, &(&1.filename == "lib/hello.ex"))
+      assert hello_file.coverage == 100
+      assert hello_file.sloc == 3
+      assert hello_file.misses == 0
+    end
+  end
+
+  describe "CoverageCiPoster.get_coverage_stats_multi/1" do
+    test "returns merged line coverage tuples from both apps", ctx do
+      Cover.compile([@hello_beam_dir, ctx.project_ebin])
+      call_hello()
+
+      path_pairs = [
+        {@hello_compile_root, @hello_runtime_root},
+        {ctx.project_root, ctx.project_root}
+      ]
+
+      stats = CoverageCiPoster.get_coverage_stats_multi(path_pairs)
+      assert is_list(stats)
+
+      file_paths = Enum.map(stats, fn {path, _} -> path end)
+      assert "lib/hello.ex" in file_paths
+
+      # Project files are present
+      other_files = Enum.filter(file_paths, &(&1 != "lib/hello.ex"))
+      assert length(other_files) > 0
+
+      # Hello's line coverage array has 23 elements (source file is 23 lines)
+      {_, hello_coverage} = Enum.find(stats, fn {p, _} -> p == "lib/hello.ex" end)
+      assert length(hello_coverage) == 23
+      # line 16 (0-indexed: 15) was executed
+      assert Enum.at(hello_coverage, 15) > 0
+    end
+  end
+
+  describe "single-app degenerate case" do
+    test "multi functions work correctly with one path pair" do
+      Cover.compile([@hello_beam_dir])
+      call_hello()
+
+      path_pairs = [{@hello_compile_root, @hello_runtime_root}]
+
+      coverage = ExIntegrationCoveralls.get_total_coverage_multi(path_pairs)
+      assert coverage == 100
+
+      report = ExIntegrationCoveralls.get_coverage_report_multi(path_pairs)
+      assert length(report.files) == 1
+      assert hd(report.files).filename == "lib/hello.ex"
+    end
+  end
+
+  describe "zero coverage in multi-app context" do
+    test "unexercised code shows 0% coverage" do
+      Cover.compile([@hello_beam_dir])
+      # Do NOT call call_hello()
+
+      path_pairs = [{@hello_compile_root, @hello_runtime_root}]
+
+      report = ExIntegrationCoveralls.get_coverage_report_multi(path_pairs)
+      hello_file = hd(report.files)
+      assert hello_file.coverage == 0
+      assert hello_file.misses == 3
+      assert hello_file.hits == 0
+    end
+  end
+end

--- a/test/path_reader_test.exs
+++ b/test/path_reader_test.exs
@@ -1,5 +1,5 @@
 defmodule ExIntegrationCoveralls.PathReaderTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mock
   alias ExIntegrationCoveralls.PathReader
 
@@ -48,27 +48,18 @@ defmodule ExIntegrationCoveralls.PathReaderTest do
     assert(PathReader.expand_path("test", File.cwd!()) == File.cwd!() <> "/test")
   end
 
-  # test_with_mock "get app cover path", Application,
-  #   app_dir: fn _ -> PathReader.expand_path(@application_dir) end do
-  #   {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, app_beam_dir} =
-  #     PathReader.get_app_cover_path("ex_integration_coveralls")
-
-  #   assert(run_time_source_lib_abs_path == PathReader.expand_path("test/fixtures/hello"))
-  #   assert(compile_time_source_lib_abs_path == "/private/tmp/hello")
-  #   assert(app_beam_dir == PathReader.expand_path("test/fixtures/hello/ebin"))
-  # end
-
   test "get app cover path" do
-    with_mocks([
-      {Application, [], [app_dir: fn _ -> PathReader.expand_path(@application_dir) end]},
-      {:beam_lib, [:unstick], [chunks: fn _, _ -> @beam_debug_info end]}
-    ]) do
+    # Use the real Application.app_dir and only mock :beam_lib to control compile-time path.
+    # Mocking Application is unsafe because it's a core OTP module used by Logger, ExUnit, etc.
+    app_dir = Application.app_dir(:ex_integration_coveralls)
+
+    with_mock :beam_lib, [:unstick], chunks: fn _, _ -> @beam_debug_info end do
       {run_time_source_lib_abs_path, compile_time_source_lib_abs_path, app_beam_dir} =
         PathReader.get_app_cover_path("ex_integration_coveralls")
 
-      assert(run_time_source_lib_abs_path == PathReader.expand_path("test/fixtures/hello"))
+      assert(run_time_source_lib_abs_path == app_dir)
       assert(compile_time_source_lib_abs_path == "/private/tmp/hello")
-      assert(app_beam_dir == PathReader.expand_path("test/fixtures/hello/ebin"))
+      assert(app_beam_dir == app_dir <> "/ebin")
     end
   end
 
@@ -80,5 +71,25 @@ defmodule ExIntegrationCoveralls.PathReaderTest do
 
     assert(commit_id == "702c1d15e59d87707dbd4676960238efc598f740")
     assert(branch == "main")
+  end
+
+  test "get apps cover paths returns list of tuples" do
+    app_dir = Application.app_dir(:ex_integration_coveralls)
+
+    with_mock :beam_lib, [:unstick], chunks: fn _, _ -> @beam_debug_info end do
+      result =
+        PathReader.get_apps_cover_paths([
+          "ex_integration_coveralls",
+          "ex_integration_coveralls"
+        ])
+
+      assert length(result) == 2
+
+      Enum.each(result, fn {runtime, compile_time, beam_dir} ->
+        assert runtime == app_dir
+        assert compile_time == "/private/tmp/hello"
+        assert beam_dir == app_dir <> "/ebin"
+      end)
+    end
   end
 end

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -280,4 +280,37 @@ defmodule ExIntegrationCoveralls.StatsTest do
     results = Stats.transform_cov(@fractional_source_info)
     assert(results.coverage == 66.7)
   end
+
+  test "trim_empty_prefix_and_suffix removes leading newline" do
+    assert Stats.trim_empty_prefix_and_suffix("\nhello") == "hello"
+  end
+
+  test "trim_empty_prefix_and_suffix removes trailing newline" do
+    assert Stats.trim_empty_prefix_and_suffix("hello\n") == "hello"
+  end
+
+  test "trim_empty_prefix_and_suffix removes both leading and trailing newlines" do
+    assert Stats.trim_empty_prefix_and_suffix("\nhello\n") == "hello"
+  end
+
+  test "trim_empty_prefix_and_suffix leaves inner newlines" do
+    assert Stats.trim_empty_prefix_and_suffix("hello\nworld") == "hello\nworld"
+  end
+
+  test "trim_empty_prefix_and_suffix with no newlines" do
+    assert Stats.trim_empty_prefix_and_suffix("hello") == "hello"
+  end
+
+  test "read_source reads and trims file content" do
+    source = Stats.read_source(PathReader.expand_path("test/fixtures/test.ex"))
+    assert is_binary(source)
+    refute String.starts_with?(source, "\n")
+    refute String.ends_with?(source, "\n")
+  end
+
+  test "get_source_line_count returns correct count" do
+    count = Stats.get_source_line_count(PathReader.expand_path("test/fixtures/test.ex"))
+    assert is_integer(count)
+    assert count > 0
+  end
 end


### PR DESCRIPTION
Support collecting coverage across a main app and its dependency libraries in a single session. This enables real-world scenarios where business logic is split across multiple OTP apps.

Changes:
- Add dep_apps option to start_app_cov, get_app_total_cov, get_app_coverage_report, and post_app_cov_to_ci
- Add Cover.modules_for_compile_root/1 to partition modules by app
- Add release-compatible source resolution via beam debug_info fallback when module_info(:compile) is stripped
- Add multi-app HTTP API endpoints (dep_apps query param)
- Add defensive rescue in CovStatsWorker handle_cast clauses
- Add E2E tests (real :cover, no mocks) for multi-app pipeline
- Add dep_lib example and update release_demo with dep_apps demo
- Split README into English/Chinese with cross-reference links